### PR TITLE
-Correct a few bad MIDI drum mappings.

### DIFF
--- a/magenta/models/music_vae/configs.py
+++ b/magenta/models/music_vae/configs.py
@@ -517,7 +517,9 @@ CONFIG_MAP['groovae_4bar'] = Config(
     note_sequence_augmenter=None,
     data_converter=data.GrooveConverter(
         split_bars=4, steps_per_quarter=4, quarters_per_bar=4,
-        max_tensors_per_notesequence=20),
+        max_tensors_per_notesequence=20,
+        pitch_classes=data.ROLAND_DRUM_PITCH_CLASSES,
+        inference_pitch_classes=data.REDUCED_DRUM_PITCH_CLASSES),
     train_examples_path=None,
     eval_examples_path=None,
 )
@@ -537,7 +539,9 @@ CONFIG_MAP['groovae_2bar_humanize'] = Config(
     note_sequence_augmenter=None,
     data_converter=data.GrooveConverter(
         split_bars=2, steps_per_quarter=4, quarters_per_bar=4,
-        max_tensors_per_notesequence=20, humanize=True),
+        max_tensors_per_notesequence=20, humanize=True,
+        pitch_classes=data.ROLAND_DRUM_PITCH_CLASSES,
+        inference_pitch_classes=data.REDUCED_DRUM_PITCH_CLASSES),
     train_examples_path=None,
     eval_examples_path=None,
 )
@@ -557,7 +561,9 @@ CONFIG_MAP['groovae_2bar_tap_fixed_velocity'] = Config(
     note_sequence_augmenter=None,
     data_converter=data.GrooveConverter(
         split_bars=2, steps_per_quarter=4, quarters_per_bar=4,
-        max_tensors_per_notesequence=20, tapify=True, fixed_velocities=True),
+        max_tensors_per_notesequence=20, tapify=True, fixed_velocities=True,
+        pitch_classes=data.ROLAND_DRUM_PITCH_CLASSES,
+        inference_pitch_classes=data.REDUCED_DRUM_PITCH_CLASSES),
     train_examples_path=None,
     eval_examples_path=None,
 )
@@ -577,7 +583,9 @@ CONFIG_MAP['groovae_2bar_add_closed_hh'] = Config(
     note_sequence_augmenter=None,
     data_converter=data.GrooveConverter(
         split_bars=2, steps_per_quarter=4, quarters_per_bar=4,
-        max_tensors_per_notesequence=20, add_instruments=[2]),
+        max_tensors_per_notesequence=20, add_instruments=[2],
+        pitch_classes=data.ROLAND_DRUM_PITCH_CLASSES,
+        inference_pitch_classes=data.REDUCED_DRUM_PITCH_CLASSES),
     train_examples_path=None,
     eval_examples_path=None,
 )
@@ -597,7 +605,9 @@ CONFIG_MAP['groovae_2bar_hits_control'] = Config(
     note_sequence_augmenter=None,
     data_converter=data.GrooveConverter(
         split_bars=2, steps_per_quarter=4, quarters_per_bar=4,
-        max_tensors_per_notesequence=20, hits_as_controls=True),
+        max_tensors_per_notesequence=20, hits_as_controls=True,
+        pitch_classes=data.ROLAND_DRUM_PITCH_CLASSES,
+        inference_pitch_classes=data.REDUCED_DRUM_PITCH_CLASSES),
     train_examples_path=None,
     eval_examples_path=None,
 )

--- a/magenta/models/music_vae/trained_model.py
+++ b/magenta/models/music_vae/trained_model.py
@@ -60,6 +60,7 @@ class TrainedModel(object):
     else:
       checkpoint_path = checkpoint_dir_or_path
     self._config = copy.deepcopy(config)
+    self._config.set_mode('infer')
     self._config.hparams.batch_size = batch_size
     with tf.Graph().as_default():
       model = self._config.model

--- a/magenta/music/drums_encoder_decoder.py
+++ b/magenta/music/drums_encoder_decoder.py
@@ -21,32 +21,32 @@ from magenta.music import encoder_decoder
 # attempts to map all GM1 and GM2 drums onto a much smaller standard drum kit
 # based on drum sound and function.
 DEFAULT_DRUM_TYPE_PITCHES = [
-    # bass drum
+    # kick drum
     [36, 35],
 
     # snare drum
     [38, 27, 28, 31, 32, 33, 34, 37, 39, 40, 56, 65, 66, 75, 85],
 
     # closed hi-hat
-    [42, 44, 54, 68, 69, 70, 71, 73, 78, 80],
+    [42, 44, 54, 68, 69, 70, 71, 73, 78, 80, 22],
 
     # open hi-hat
-    [46, 67, 72, 74, 79, 81],
+    [46, 67, 72, 74, 79, 81, 26],
 
     # low tom
-    [45, 29, 41, 61, 64, 84],
+    [45, 29, 41, 43, 61, 64, 84],
 
     # mid tom
     [48, 47, 60, 63, 77, 86, 87],
 
     # high tom
-    [50, 30, 43, 62, 76, 83],
+    [50, 30, 62, 76, 83],
 
     # crash cymbal
-    [49, 55, 57, 58],
+    [49, 52, 55, 57, 58],
 
     # ride cymbal
-    [51, 52, 53, 59, 82]
+    [51, 53, 59, 82]
 ]
 
 


### PR DESCRIPTION
-Add support for inference mode in MusicVAE DataConverters.
-Add Roland V-Drum pitch mapping for GrooveConverters.
-Use Roland mapping for GrooVAE models during training and the default reduced mapping during inference.

PiperOrigin-RevId: 245084236